### PR TITLE
Simplify process and instructions

### DIFF
--- a/.github/workflows/AutoInviteToOrgByNewIssue.py
+++ b/.github/workflows/AutoInviteToOrgByNewIssue.py
@@ -25,7 +25,7 @@ USERNAME = data["issue"]["user"]["login"] # assumes this value is always present
 # print("USERNAME:")
 # print(USERNAME)
 
-if "RaiseHigh" not in COMMENT:
+if "RAISEHIGH" not in COMMENT.upper():
   sys.exit()
 else:
 

--- a/.github/workflows/AutoInviteToOrgByNewIssue.py
+++ b/.github/workflows/AutoInviteToOrgByNewIssue.py
@@ -18,19 +18,16 @@ data = json.load(file)
 # print(data)
 
 COMMENT = data["issue"]["title"]
-USERNAME = data["issue"]["user"]["login"]
+USERNAME = data["issue"]["user"]["login"] # assumes this value is always present
 
 # print("COMMENT:")
 # print(COMMENT)
 # print("USERNAME:")
 # print(USERNAME)
 
-if "RaiseHigh @" not in COMMENT and "RaiseHigh me" not in COMMENT:
+if "RaiseHigh" not in COMMENT:
   sys.exit()
 else:
-
-  if "RaiseHigh @" in COMMENT:
-    USERNAME = COMMENT.replace("RaiseHigh @", "")
 
   print('Send invite for the @'+USERNAME)
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ To use this service, you must be invited to the 'GWUniversity' github organizati
   ![Repository Issues](RepoTitle.png)
 - Create a New Issue
   ![New Issue Dialog](NewIssueDialog.png)
-- The ISSUE MUST BE Titled: RaiseHigh @githubusername OR RaiseHigh me
+- The ISSUE TITLE MUST INCLUDE THE PHRASE "RaiseHigh"
 - Submit the issue
   ![Submit Issue](SubmitIssue.png)
   


### PR DESCRIPTION
Handle a single more flexible scenario for issue parsing - if we already have the user's handle from the event data, we can just use that. This will help simplify the instructions as well - we can just tell someone to say "RaiseHigh", so there is no confusion about using their specific handle.