### PR TITLE
Added the github stale action to help maintain issues that were left open

### DIFF
--- a/.github/workflows/invite-by-issue.yml
+++ b/.github/workflows/invite-by-issue.yml
@@ -8,9 +8,9 @@ jobs:
 
       steps:
         - name: checkout repo content
-          uses: actions/checkout@v2
+          uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #5.0.0
         - name: setup python
-          uses: actions/setup-python@v2
+          uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c #6.0.0
           with:
             python-version: 3.8
         - name: Install dependencies

--- a/.github/workflows/stale-issues-cleanup.yml
+++ b/.github/workflows/stale-issues-cleanup.yml
@@ -1,4 +1,4 @@
-name: 'Close stale issues and PRs'
+name: 'Close stale issues'
 on:
   workflow_dispatch:
   schedule:
@@ -11,7 +11,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@3a9db7e6a41a89f618792c92c0e97cc736e1b13f
+      - uses: actions/stale@3a9db7e6a41a89f618792c92c0e97cc736e1b13f  #v10
         with:
           stale-issue-message: 'This issue is stale because it has been open 14 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
           days-before-stale: 14

--- a/.github/workflows/stale-issues-cleanup.yml
+++ b/.github/workflows/stale-issues-cleanup.yml
@@ -1,0 +1,18 @@
+name: 'Close stale issues and PRs'
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '30 5 * * *'
+
+permissions:
+  issues: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@3a9db7e6a41a89f618792c92c0e97cc736e1b13f
+        with:
+          stale-issue-message: 'This issue is stale because it has been open 14 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
+          days-before-stale: 14
+          days-before-close: 5


### PR DESCRIPTION
-Updated the uses for both workflows to use commit sha, these actions were also updated to latest versions 
-Runs daily at 5:30
-Adds stale label + message to the issue when open but unmodified for 14 days
-Closes the issue after 5 additional days if label not remove, or issue not updated




**Leaving this PR for team to review during Wednesday meeting** 